### PR TITLE
Provide `Material#dup()` to facilitate making changes on a deep clone of a material config

### DIFF
--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/DependencyMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/DependencyMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -27,6 +28,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -64,4 +66,24 @@ public class DependencyMaterial extends Material<DependencyMaterial> {
         configure(cl);
     }
 
+    public DependencyMaterial(String name, Consumer<DependencyMaterial> config) {
+        super(name);
+        config.accept(this);
+    }
+
+    @Override
+    public DependencyMaterial dup(
+            @DelegatesTo(value = DependencyMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.DependencyMaterial")
+                    Closure<DependencyMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    private DependencyMaterial deepClone() {
+        return new DependencyMaterial(name, d -> {
+            d.pipeline = pipeline;
+            d.stage = stage;
+            d.ignoreForScheduling = ignoreForScheduling;
+        });
+    }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/Filter.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/Filter.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -57,4 +58,7 @@ public class Filter {
         this.items = items;
     }
 
+    public Filter deepClone() {
+        return new Filter(isWhitelist, new ArrayList<>(items));
+    }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/GitHubPRMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/GitHubPRMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -27,6 +28,7 @@ import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -40,6 +42,9 @@ public class GitHubPRMaterial extends ScmMaterial<GitHubPRMaterial> {
 
     private String branch;
 
+    public GitHubPRMaterial(String name, Consumer<GitHubPRMaterial> configure) {
+        super(name, configure);
+    }
 
     public GitHubPRMaterial(@DelegatesTo(value = GitHubPRMaterial.class, strategy = DELEGATE_ONLY) @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.GitHubPRMaterial") Closure cl) {
         this(null, cl);
@@ -50,6 +55,14 @@ public class GitHubPRMaterial extends ScmMaterial<GitHubPRMaterial> {
         configure(cl);
     }
 
+    @Override
+    public GitHubPRMaterial dup(
+            @DelegatesTo(value = GitHubPRMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.GitHubPRMaterial")
+                    Closure<GitHubPRMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
     public Object toPluggableMaterial() {
         LinkedHashMap<Object, Object> result = new LinkedHashMap<>();
         result.put("name", name);
@@ -57,6 +70,15 @@ public class GitHubPRMaterial extends ScmMaterial<GitHubPRMaterial> {
         result.put("plugin_configuration", pluginConfig());
         result.put("configuration", configuration());
         return result;
+    }
+
+    @Override
+    protected GitHubPRMaterial deepClone() {
+        return new GitHubPRMaterial(name, g -> {
+            injectSettings(g);
+            g.url = url;
+            g.branch = branch;
+        });
     }
 
     private Object configuration() {

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/GitMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/GitMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -83,5 +84,23 @@ public class GitMaterial extends ScmMaterial<GitMaterial> {
 
     public GitMaterial(String name, Consumer<GitMaterial> configure) {
         super(name, configure);
+    }
+
+    @Override
+    public GitMaterial dup(
+            @DelegatesTo(value = GitMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.GitMaterial")
+                    Closure<GitMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    @Override
+    protected GitMaterial deepClone() {
+        return new GitMaterial(name, g -> {
+            injectSettings(g);
+            g.url = url;
+            g.branch = branch;
+            g.shallowClone = shallowClone;
+        });
     }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/HgMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/HgMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -27,6 +28,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -62,4 +64,23 @@ public class HgMaterial extends ScmMaterial<HgMaterial> {
         configure(cl);
     }
 
+    public HgMaterial(String name, Consumer<HgMaterial> configure) {
+        super(name, configure);
+    }
+
+    @Override
+    public HgMaterial dup(
+            @DelegatesTo(value = HgMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.HgMaterial")
+                    Closure<HgMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    @Override
+    protected HgMaterial deepClone() {
+        return new HgMaterial(name, h -> {
+            injectSettings(h);
+            h.url = url;
+        });
+    }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/Material.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/Material.java
@@ -18,6 +18,7 @@ package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import groovy.lang.Closure;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -57,4 +58,5 @@ public abstract class Material<T extends Material> extends NamedNode<T> {
         super(name);
     }
 
+    public abstract T dup(Closure<T> config);
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/P4Material.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/P4Material.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -27,6 +28,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -55,6 +57,10 @@ public class P4Material extends ScmMaterial<P4Material> {
     @NotEmpty
     private String view;
 
+    public P4Material(String name, Consumer<P4Material> configure) {
+        super(name, configure);
+    }
+
     public P4Material() {
         this(null);
     }
@@ -66,6 +72,24 @@ public class P4Material extends ScmMaterial<P4Material> {
     public P4Material(String name, @DelegatesTo(value = P4Material.class, strategy = DELEGATE_ONLY) @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.P4Material") Closure cl) {
         super(name);
         configure(cl);
+    }
+
+    @Override
+    public P4Material dup(
+            @DelegatesTo(value = P4Material.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.P4Material")
+                    Closure<P4Material> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    @Override
+    protected P4Material deepClone() {
+        return new P4Material(name, p -> {
+            injectSettings(p);
+            p.port = port;
+            p.view = view;
+            p.useTickets = useTickets;
+        });
     }
 
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/PackageMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/PackageMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -27,6 +28,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -53,4 +55,22 @@ public class PackageMaterial extends Material<PackageMaterial> {
         configure(cl);
     }
 
+    public PackageMaterial(String name, Consumer<PackageMaterial> config) {
+        super(name);
+        config.accept(this);
+    }
+
+    @Override
+    public PackageMaterial dup(
+            @DelegatesTo(value = PackageMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.PackageMaterial")
+                    Closure<PackageMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    private PackageMaterial deepClone() {
+        return new PackageMaterial(name, p -> {
+            p.ref = ref;
+        });
+    }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/ScmMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/ScmMaterial.java
@@ -36,7 +36,6 @@ import static lombok.AccessLevel.NONE;
 @ToString(callSuper = true)
 public abstract class ScmMaterial<T extends ScmMaterial> extends Material<T> {
 
-
     @JsonProperty("username")
     protected String username;
 
@@ -74,7 +73,6 @@ public abstract class ScmMaterial<T extends ScmMaterial> extends Material<T> {
     @JsonProperty("auto_update")
     private Boolean autoUpdate = true;
 
-
     /**
      * The {@link Filter} element specifies files in changesets that should not trigger a pipeline automatically. When a
      * pipeline is triggered by files that are not ignored the filtered files will still be updated with other files.
@@ -103,11 +101,27 @@ public abstract class ScmMaterial<T extends ScmMaterial> extends Material<T> {
         configure.accept((T) this);
     }
 
+    @JsonIgnore
+    public List<String> getBlacklist() {
+        if (this.filter != null && !this.filter.isWhitelist()) {
+            return this.filter.getItems();
+        }
+        return null;
+    }
+
     /**
      * {@includeCode scm.blacklist.groovy }
      */
     public void setBlacklist(List<String> blacklist) {
         filter = new Filter(blacklist);
+    }
+
+    @JsonIgnore
+    public List<String> getWhitelist() {
+        if (this.filter != null && this.filter.isWhitelist()) {
+            return this.filter.getItems();
+        }
+        return null;
     }
 
     /**
@@ -117,19 +131,19 @@ public abstract class ScmMaterial<T extends ScmMaterial> extends Material<T> {
         filter = new Filter(true, whitelist);
     }
 
-    @JsonIgnore
-    public List<String> getBlacklist() {
-        if (this.filter != null && !this.filter.isWhitelist()) {
-            return this.filter.getItems();
-        }
-        return null;
-    }
+    protected abstract T deepClone();
 
-    @JsonIgnore
-    public List<String> getWhitelist() {
-        if (this.filter != null && this.filter.isWhitelist()) {
-            return this.filter.getItems();
+    @SuppressWarnings("unchecked")
+    protected T injectSettings(ScmMaterial<T> other) {
+        other.username = username;
+        other.password = password;
+        other.encryptedPassword = encryptedPassword;
+        other.autoUpdate = autoUpdate;
+        other.destination = destination;
+        if (null != filter) {
+            other.filter = filter.deepClone();
         }
-        return null;
+
+        return (T) other;
     }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/SvnMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/SvnMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
@@ -27,6 +28,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.Valid;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -65,4 +67,24 @@ public class SvnMaterial extends ScmMaterial<SvnMaterial> {
         configure(cl);
     }
 
+    public SvnMaterial(String name, Consumer<SvnMaterial> configure) {
+        super(name, configure);
+    }
+
+    @Override
+    public SvnMaterial dup(
+            @DelegatesTo(value = SvnMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.SvnMaterial")
+                    Closure<SvnMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    @Override
+    protected SvnMaterial deepClone() {
+        return new SvnMaterial(name, s -> {
+            injectSettings(s);
+            s.url = url;
+            s.checkExternals = checkExternals;
+        });
+    }
 }

--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/TfsMaterial.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/TfsMaterial.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.dsl;
 
+import cd.go.contrib.plugins.configrepo.groovy.dsl.mixins.Configurable;
 import groovy.lang.Closure;
 import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
@@ -26,6 +27,7 @@ import lombok.Setter;
 import lombok.ToString;
 
 import javax.validation.constraints.NotBlank;
+import java.util.function.Consumer;
 
 import static groovy.lang.Closure.DELEGATE_ONLY;
 
@@ -73,4 +75,24 @@ public class TfsMaterial extends ScmMaterial<TfsMaterial> {
         configure(cl);
     }
 
+    public TfsMaterial(String name, Consumer<TfsMaterial> configure) {
+        super(name, configure);
+    }
+
+    @Override
+    public TfsMaterial dup(
+            @DelegatesTo(value = TfsMaterial.class, strategy = DELEGATE_ONLY)
+            @ClosureParams(value = SimpleType.class, options = "cd.go.contrib.plugins.configrepo.groovy.dsl.TfsMaterial")
+                    Closure<TfsMaterial> config) {
+        return Configurable.applyTo(config, deepClone());
+    }
+
+    @Override
+    protected TfsMaterial deepClone() {
+        return new TfsMaterial(name, t -> {
+            t.url = url;
+            t.domain = domain;
+            t.projectPath = projectPath;
+        });
+    }
 }

--- a/dsl/src/test/java/cd/go/contrib/plugins/configrepo/groovy/dsl/TestAllSignatures.java
+++ b/dsl/src/test/java/cd/go/contrib/plugins/configrepo/groovy/dsl/TestAllSignatures.java
@@ -50,7 +50,7 @@ class TestAllSignatures {
         assertThat(actualNodeTypes).isEqualTo(ALL_KNOWN_NODE_TYPES);
     }
 
-    private static ScanResult scanResult = new ClassGraph()
+    private static final ScanResult scanResult = new ClassGraph()
 //            .verbose()
             .enableClassInfo()
             .enableMethodInfo()
@@ -116,9 +116,11 @@ class TestAllSignatures {
     @ParameterizedTest
     @MethodSource("methodsReturningNodeType")
     void verifyFactoryMethodSignatures(Method method) {
-        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-        int closureParamIndex = Arrays.asList(method.getParameterTypes()).indexOf(Closure.class);
-        assertParameterAnnotations(method.getReturnType(), parameterAnnotations[closureParamIndex]);
+        if (!Modifier.isAbstract(method.getModifiers())) {
+            Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+            int closureParamIndex = Arrays.asList(method.getParameterTypes()).indexOf(Closure.class);
+            assertParameterAnnotations(method.getReturnType(), parameterAnnotations[closureParamIndex]);
+        }
     }
 
     private static Stream<Class<Node>> allNodeTypes() {


### PR DESCRIPTION
In branch scanning blocks, one may need to duplicate material configs with minor tweaks across workflows. This makes this easier:

```groovy
materials {
  add((ctx.repo as GitMaterial).dup {
    destination = 'other/path'
    name = 'other'
  })
}
```