### PR TITLE
Make nicer shortRefs for GitHub and GitLab that don't end in `/head`

### DIFF
--- a/resolvers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/resolvers/Branches.java
+++ b/resolvers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/resolvers/Branches.java
@@ -67,7 +67,7 @@ public class Branches {
      * @return a {@link List} of {@link BranchContext} instances
      */
     public static List<BranchContext> stubbed(final BranchStrategy s, @SuppressWarnings("unused") final Pattern p) {
-        final String ref = "stubbed-ref-" + randomHex();
+        final String ref = "refs/heads/stubbed-ref-" + randomHex();
 
         return Collections.singletonList(createContext(s.attrs(), new MergeParent() {
             @Override


### PR DESCRIPTION
This way, the user doesn't need to manually trim off before interpolating in a pipeline name or similar.