### PR TITLE
Extract more pull request metadata

### DIFF
--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/BranchContext.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/BranchContext.java
@@ -24,20 +24,42 @@ import lombok.Setter;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Getter
 @Setter
 public class BranchContext implements KeyVal.Mixin {
 
+    /**
+     * Required for JSON deserialization
+     */
+    @SuppressWarnings("unused")
     public BranchContext() {
     }
 
+    @SuppressWarnings("rawtypes")
     public BranchContext(@NotEmpty String fullRefName, @NotEmpty String branch, @NotNull ScmMaterial repo) {
         this.fullRefName = fullRefName;
         this.branch = branch;
         this.branchSanitized = RefUtils.sanitizeRef(branch);
         this.repo = repo;
     }
+
+    @JsonProperty
+    @NotEmpty
+    private String title;
+
+    @JsonProperty
+    @NotNull
+    private String author;
+
+    @JsonProperty("reference_url")
+    @NotNull
+    private String referenceUrl;
+
+    @JsonProperty
+    @NotNull
+    private List<String> labels;
 
     @JsonProperty("full_ref_name")
     @NotEmpty
@@ -51,7 +73,8 @@ public class BranchContext implements KeyVal.Mixin {
     @NotEmpty
     private String branchSanitized;
 
-    @JsonProperty("repo")
+    @JsonProperty
     @NotNull
+    @SuppressWarnings("rawtypes")
     private ScmMaterial repo;
 }

--- a/json/src/test/java/cd/go/contrib/plugins/configrepo/groovy/dsl/BranchContextSerializationTest.java
+++ b/json/src/test/java/cd/go/contrib/plugins/configrepo/groovy/dsl/BranchContextSerializationTest.java
@@ -34,6 +34,10 @@ class BranchContextSerializationTest {
                 "\"branch_name\": \"foo\"," +
                 "\"sanitized_branch_name\": \"foo\"," +
                 "\"full_ref_name\": \"refs/heads/foo\"," +
+                "\"title\": \"this is a foo\"," +
+                "\"author\": \"me\"," +
+                "\"reference_url\": \"https://pull/request\"," +
+                "\"labels\": [\"a\", \"b\"]," +
                 "\"repo\": {" +
                 "    \"type\": \"git\"," +
                 "    \"url\": \"https://gitbud.com/repo.git\"," +
@@ -49,6 +53,10 @@ class BranchContextSerializationTest {
 
         assertEquals("foo", c.getBranch());
         assertEquals("https://gitbud.com/repo.git", ((GitMaterial) c.getRepo()).getUrl());
+        assertEquals("this is a foo", c.getTitle());
+        assertEquals("me", c.getAuthor());
+        assertEquals("https://pull/request", c.getReferenceUrl());
+        assertEquals(List.of("a", "b"), c.getLabels());
     }
 
     @Test
@@ -57,6 +65,10 @@ class BranchContextSerializationTest {
                 "\"branch_name\": \"foo\"," +
                 "\"sanitized_branch_name\": \"foo\"," +
                 "\"full_ref_name\": \"refs/heads/foo\"," +
+                "\"title\": \"this is a foo\"," +
+                "\"author\": \"me\"," +
+                "\"reference_url\": \"https://pull/request\"," +
+                "\"labels\": [\"a\", \"b\"]," +
                 "\"repo\": {" +
                 "    \"type\": \"git\"," +
                 "    \"url\": \"https://gitbud.com/repo.git\"," +
@@ -77,6 +89,10 @@ class BranchContextSerializationTest {
 
         assertEquals("foo", c.getBranch());
         assertEquals("https://gitbud.com/repo.git", ((GitMaterial) c.getRepo()).getUrl());
+        assertEquals("this is a foo", c.getTitle());
+        assertEquals("me", c.getAuthor());
+        assertEquals("https://pull/request", c.getReferenceUrl());
+        assertEquals(List.of("a", "b"), c.getLabels());
     }
 
 }

--- a/providers/build.gradle
+++ b/providers/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jupiterVersion
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: jupiterVersion
   testImplementation group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+  testImplementation group: 'org.codehaus.groovy', name: 'groovy-json', version: groovyVersion
 }
 
 test {

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/BasicGitRefProvider.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/BasicGitRefProvider.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static cd.go.contrib.plugins.configrepo.groovy.dsl.util.RefUtils.gitShortRef;
 import static cd.go.contrib.plugins.configrepo.groovy.dsl.util.UriUtils.embedAuth;
 import static cd.go.contrib.plugins.configrepo.groovy.dsl.util.UriUtils.maskAuth;
 import static cd.go.contrib.plugins.configrepo.groovy.utils.CommandUtils.*;
@@ -78,7 +79,7 @@ public class BasicGitRefProvider implements RefProvider {
         return refs;
     }
 
-    public static class GitRef implements MergeParent {
+    public static class GitRef implements MergeCandidate {
 
         private final String ref;
 
@@ -97,6 +98,26 @@ public class BasicGitRefProvider implements RefProvider {
         @Override
         public String url() {
             return url;
+        }
+
+        @Override
+        public String title() {
+            return gitShortRef(ref);
+        }
+
+        @Override
+        public String author() {
+            return null;
+        }
+
+        @Override
+        public String showUrl() {
+            return null;
+        }
+
+        @Override
+        public List<String> labels() {
+            return null;
         }
     }
 }

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/MergeCandidate.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/MergeCandidate.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.plugins.configrepo.groovy.branching;
+
+import java.util.List;
+
+public interface MergeCandidate extends MergeParent {
+
+    String title();
+
+    String author();
+
+    String showUrl();
+
+    List<String> labels();
+
+}

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/RefProvider.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/RefProvider.java
@@ -20,5 +20,5 @@ import java.util.List;
 
 public interface RefProvider {
 
-    List<? extends MergeParent> fetch();
+    List<? extends MergeCandidate> fetch();
 }

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/PullRequest.java
@@ -16,14 +16,18 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.branching.api.bitbucketcloud;
 
-import cd.go.contrib.plugins.configrepo.groovy.branching.MergeParent;
+import cd.go.contrib.plugins.configrepo.groovy.branching.MergeCandidate;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.firstNonBlank;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PullRequest implements MergeParent {
+public class PullRequest implements MergeCandidate {
 
     @JsonProperty
     @SuppressWarnings("unused")
@@ -33,11 +37,56 @@ public class PullRequest implements MergeParent {
     @SuppressWarnings("unused")
     private MergeEndpoint destination;
 
+    @JsonProperty
+    @SuppressWarnings("unused")
+    private String title;
+
+    private String author;
+
+    private String showUrl;
+
+    @Override
+    public String ref() {
+        return source.ref();
+    }
+
+    @Override
     public String url() {
         return firstNonBlank(source.url(), destination.url());
     }
 
-    public String ref() {
-        return source.ref();
+    @Override
+    public String title() {
+        return title;
+    }
+
+    @Override
+    public String author() {
+        return author;
+    }
+
+    @Override
+    public String showUrl() {
+        return showUrl;
+    }
+
+    @Override
+    public List<String> labels() {
+        return null;
+    }
+
+    @JsonProperty("author")
+    @SuppressWarnings({"unused"})
+    private void unpackAuthor(Map<String, Object> node) {
+        author = (String) requireNonNull(node.get("nickname"));
+    }
+
+    @JsonProperty("links")
+    @SuppressWarnings({"unused", "unchecked"})
+    private void unpackLinks(Map<String, Object> node) {
+        showUrl = requireNonNull((String) requireNonNull(
+                (Map<String, Object>) node.get("html"),
+                "Missing PR html link entry"
+        ).get("href"), "Missing PR html link href");
     }
 }

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/GitlabService.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/GitlabService.java
@@ -32,10 +32,10 @@ public interface GitlabService {
 
     String PAGINATION_HEADER = "x-next-page";
 
-    @GET("api/v4/projects/{id}/merge_requests?state=opened&view=simple")
+    @GET("api/v4/projects/{id}/merge_requests?state=opened")
     Call<List<PullRequest>> pullRequests(@Path("id") String id);
 
-    @GET("api/v4/projects/{id}/merge_requests?state=opened&view=simple")
+    @GET("api/v4/projects/{id}/merge_requests?state=opened")
     Call<List<PullRequest>> pullRequests(@Path("id") String id, @Query("page") int page);
 
     default List<PullRequest> allPullRequests(String owner, String repo) throws IOException {

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/PullRequest.java
@@ -16,28 +16,38 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.branching.api.gitlab;
 
-import cd.go.contrib.plugins.configrepo.groovy.branching.MergeParent;
+import cd.go.contrib.plugins.configrepo.groovy.branching.MergeCandidate;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+import java.util.Map;
+
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PullRequest implements MergeParent {
+public class PullRequest implements MergeCandidate {
 
-    public static final String TO_REPO_URL = "/-/merge_requests/\\d+$";
+    private static final String TO_REPO_URL = "/-/merge_requests/\\d+$";
 
     @JsonProperty("iid")
     @SuppressWarnings("unused")
     private int number;
 
+    @JsonProperty
+    @SuppressWarnings("unused")
+    private String title;
+
+    private String author;
+
     private String repoUrl;
 
-    @JsonProperty("web_url")
+    private String showUrl;
+
+    @JsonProperty
     @SuppressWarnings("unused")
-    private void unpackWebUrl(String webUrl) {
-        repoUrl = webUrl.replaceAll(TO_REPO_URL, "");
-    }
+    private List<String> labels;
 
     @Override
     public String ref() {
@@ -47,5 +57,38 @@ public class PullRequest implements MergeParent {
     @Override
     public String url() {
         return repoUrl;
+    }
+
+    @Override
+    public String title() {
+        return title;
+    }
+
+    @Override
+    public String author() {
+        return author;
+    }
+
+    @Override
+    public String showUrl() {
+        return showUrl;
+    }
+
+    @Override
+    public List<String> labels() {
+        return labels;
+    }
+
+    @JsonProperty("web_url")
+    @SuppressWarnings("unused")
+    private void unpackWebUrl(String webUrl) {
+        showUrl = webUrl;
+        repoUrl = webUrl.replaceAll(TO_REPO_URL, "");
+    }
+
+    @JsonProperty("author")
+    @SuppressWarnings("unused")
+    private void unpackAuthor(Map<String, String> node) {
+        author = requireNonNull(node.get("username"), "Missing MR author username");
     }
 }

--- a/providers/src/test/groovy/cd/go/contrib/plugins/configrepo/groovy/branching/api/ApiTest.groovy
+++ b/providers/src/test/groovy/cd/go/contrib/plugins/configrepo/groovy/branching/api/ApiTest.groovy
@@ -22,11 +22,11 @@ import cd.go.contrib.plugins.configrepo.groovy.branching.api.exceptions.ClientEr
 import cd.go.contrib.plugins.configrepo.groovy.branching.api.github.GithubService
 import cd.go.contrib.plugins.configrepo.groovy.branching.api.gitlab.GitlabService
 import cd.go.contrib.plugins.configrepo.groovy.branching.api.mocks.MockedHttp
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.commons.lang3.StringUtils
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
+import static groovy.json.JsonOutput.toJson
 import static java.lang.String.format
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertThrows
@@ -91,6 +91,32 @@ class ApiTest {
       assertEquals('refs/pull/3/head', prs.get(2).ref())
       assertEquals('git.repo', prs.get(2).url())
     }
+
+    @Test
+    void 'extracts other metadata from pull request'() {
+      GithubService api = Api.github(
+        new MockedHttp().GET('/repos/gocd/gocd/pulls', { r ->
+          r.body = toJson([[
+            number: 1, state: 'open', base: [repo: [clone_url: 'git.repo']],
+            labels: [[name: 'red'], [name: 'green']],
+            title : 'Such a fancy PR',
+            user  : [login: 'the-boss'],
+            _links: [html: [href: 'https://greathub.com/pull/my/finger']]
+          ]])
+        })
+      )
+      def prs = api.allPullRequests('gocd', 'gocd')
+
+      assertEquals(1, prs.size())
+
+      def pr = prs.get(0)
+      assertEquals('refs/pull/1/head', pr.ref())
+      assertEquals('git.repo', pr.url())
+      assertEquals('Such a fancy PR', pr.title())
+      assertEquals('the-boss', pr.author())
+      assertEquals('https://greathub.com/pull/my/finger', pr.showUrl())
+      assertEquals(['red', 'green'], pr.labels())
+    }
   }
 
   @Nested
@@ -100,7 +126,7 @@ class ApiTest {
     @Test
     void 'throws error on failure response'() {
       GitlabService api = Api.gitlab(new MockedHttp().
-        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&view=simple', { r ->
+        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened', { r ->
           r.code = 422
           r.body = "dude, I'm dead."
         }), null
@@ -112,7 +138,7 @@ class ApiTest {
     @Test
     void 'fetches pull requests'() {
       GitlabService api = Api.gitlab(
-        new MockedHttp().GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&view=simple', { r ->
+        new MockedHttp().GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened', { r ->
           r.body = '[ {"iid": 5, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/5"} ]'
         }), null
       )
@@ -126,15 +152,15 @@ class ApiTest {
     @Test
     void 'fetches pull requests over multiple pages'() {
       GitlabService api = Api.gitlab(new MockedHttp().
-        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&view=simple', { r ->
+        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened', { r ->
           r.headers.add(PAGING_HEADER, '2')
           r.body = '[ {"iid": 5, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/5"} ]'
         }).
-        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&view=simple&page=2', { r ->
+        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&page=2', { r ->
           r.headers.add(PAGING_HEADER, '3')
           r.body = '[ {"iid": 6, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/6"} ]'
         }).
-        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&view=simple&page=3', { r ->
+        GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&page=3', { r ->
           r.body = '[ {"iid": 7, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/7"} ]'
         }), null
       )
@@ -150,6 +176,31 @@ class ApiTest {
 
       assertEquals('refs/merge-requests/7/head', prs.get(2).ref())
       assertEquals('https://repo.com/gocd/gocd', prs.get(2).url())
+    }
+
+    @Test
+    void 'extracts other metadata from pull request'() {
+      GitlabService api = Api.gitlab(
+        new MockedHttp().GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened', { r ->
+          r.body = toJson([[
+            iid   : 5, web_url: 'https://repo.com/gocd/gocd/-/merge_requests/5',
+            labels: ['red', 'green'],
+            title : 'Such a fancy PR',
+            author: [username: 'the-boss'],
+          ]])
+        }), null
+      )
+      def prs = api.allPullRequests('gocd', 'gocd')
+
+      assertEquals(1, prs.size())
+
+      def pr = prs.get(0)
+      assertEquals('refs/merge-requests/5/head', pr.ref())
+      assertEquals('https://repo.com/gocd/gocd', pr.url())
+      assertEquals('Such a fancy PR', pr.title())
+      assertEquals('the-boss', pr.author())
+      assertEquals('https://repo.com/gocd/gocd/-/merge_requests/5', pr.showUrl())
+      assertEquals(['red', 'green'], pr.labels())
     }
   }
 
@@ -169,10 +220,9 @@ class ApiTest {
 
     @Test
     void 'fetches pull requests'() {
-      def mapper = new ObjectMapper()
       BitBucketCloudService api = Api.bitbucketcloud(
         new MockedHttp().GET('/2.0/repositories/gocd/gocd/pullrequests?state=OPEN', { r ->
-          r.body = mapper.writeValueAsString([
+          r.body = toJson([
             page  : 1,
             values: [
               [source: internal("change"), destination: master("gocd/gocd")]
@@ -189,11 +239,10 @@ class ApiTest {
 
     @Test
     void 'fetches pull requests over multiple pages'() {
-      def mapper = new ObjectMapper()
       BitBucketCloudService api = Api.bitbucketcloud(
         new MockedHttp().
           GET('/2.0/repositories/gocd/gocd/pullrequests?state=OPEN', { r ->
-            r.body = mapper.writeValueAsString([
+            r.body = toJson([
               page  : 1,
               next  : "https://blah/blah?page=2",
               values: [
@@ -202,7 +251,7 @@ class ApiTest {
             ])
           }).
           GET('/2.0/repositories/gocd/gocd/pullrequests?state=OPEN&page=2', { r ->
-            r.body = mapper.writeValueAsString([
+            r.body = toJson([
               page  : 2,
               next  : "https://blah/blah?page=3",
               values: [
@@ -211,7 +260,7 @@ class ApiTest {
             ])
           }).
           GET('/2.0/repositories/gocd/gocd/pullrequests?state=OPEN&page=3', { r ->
-            r.body = mapper.writeValueAsString([
+            r.body = toJson([
               page  : 3,
               values: [
                 [source: internal("another"), destination: master("gocd/gocd")]
@@ -232,6 +281,34 @@ class ApiTest {
 
       assertEquals('refs/heads/another', prs.get(2).ref())
       assertEquals('https://bb.org/gocd/gocd', prs.get(2).url())
+    }
+
+    @Test
+    void 'extracts other metadata from pull request'() {
+      BitBucketCloudService api = Api.bitbucketcloud(
+        new MockedHttp().GET('/2.0/repositories/gocd/gocd/pullrequests?state=OPEN', { r ->
+          r.body = toJson([
+            page  : 1,
+            values: [[
+              source: internal("change"), destination: master("gocd/gocd"),
+              title : 'Such a fancy PR',
+              author: [nickname: 'the-boss'],
+              links : [html: [href: 'https://greathub.com/pull/my/finger']],
+            ]]
+          ])
+        })
+      )
+
+      def prs = api.allPullRequests('gocd', 'gocd')
+
+      assertEquals(1, prs.size())
+
+      def pr = prs.get(0)
+      assertEquals('refs/heads/change', pr.ref())
+      assertEquals('https://bb.org/gocd/gocd', pr.url())
+      assertEquals('Such a fancy PR', pr.title())
+      assertEquals('the-boss', pr.author())
+      assertEquals('https://greathub.com/pull/my/finger', pr.showUrl())
     }
 
     def internal(String branch) {
@@ -275,16 +352,14 @@ class ApiTest {
 
     @Test
     void 'fetches pull requests'() {
-      def mapper = new ObjectMapper()
-      BitBucketServerService api = Api.bitbucketserver(new MockedHttp().GET('/rest/api/1.0/projects/gocd/repos/gocd/pull-requests?state=OPEN', { r ->
-        r.body = mapper.writeValueAsString([
-          isLastPage: true,
-          start     : 0,
-          values    : [
-            [fromRef: from("change", "gocd/gocd")]
-          ]
-        ])
-      }), BASE_URL
+      BitBucketServerService api = Api.bitbucketserver(
+        new MockedHttp().GET('/rest/api/1.0/projects/gocd/repos/gocd/pull-requests?state=OPEN', { r ->
+          r.body = toJson([
+            isLastPage: true,
+            start     : 0,
+            values    : [[fromRef: from("change", "gocd/gocd")]]
+          ])
+        }), BASE_URL
       )
       def prs = api.allPullRequests('gocd', 'gocd')
 
@@ -295,10 +370,9 @@ class ApiTest {
 
     @Test
     void 'fetches pull requests over multiple pages'() {
-      def mapper = new ObjectMapper()
       BitBucketServerService api = Api.bitbucketserver(new MockedHttp().
         GET('/rest/api/1.0/projects/gocd/repos/gocd/pull-requests?state=OPEN', { r ->
-          r.body = mapper.writeValueAsString([
+          r.body = toJson([
             isLastPage   : false,
             nextPageStart: 1,
             values       : [
@@ -307,7 +381,7 @@ class ApiTest {
           ])
         }).
         GET('/rest/api/1.0/projects/gocd/repos/gocd/pull-requests?state=OPEN&start=1', { r ->
-          r.body = mapper.writeValueAsString([
+          r.body = toJson([
             isLastPage   : false,
             nextPageStart: 2,
             values       : [
@@ -316,7 +390,7 @@ class ApiTest {
           ])
         }).
         GET('/rest/api/1.0/projects/gocd/repos/gocd/pull-requests?state=OPEN&start=2', { r ->
-          r.body = mapper.writeValueAsString([
+          r.body = toJson([
             isLastPage: true,
             values    : [
               [fromRef: from("another", "gocd/gocd")]
@@ -337,6 +411,35 @@ class ApiTest {
 
       assertEquals('refs/heads/another', prs.get(2).ref())
       assertEquals(repoUrl('gocd/gocd'), prs.get(2).url())
+    }
+
+    @Test
+    void 'extracts other metadata from pull request'() {
+      BitBucketServerService api = Api.bitbucketserver(
+        new MockedHttp().GET('/rest/api/1.0/projects/gocd/repos/gocd/pull-requests?state=OPEN', { r ->
+          r.body = toJson([
+            isLastPage: true,
+            start     : 0,
+            values    : [[
+              fromRef: from("change", "gocd/gocd"),
+              title  : 'Such a fancy PR',
+              author : [user: [name: 'the-boss']],
+              links  : [self: [[href: 'https://greathub.com/pull/my/finger']]],
+            ]]
+          ])
+        }), BASE_URL
+      )
+
+      def prs = api.allPullRequests('gocd', 'gocd')
+
+      assertEquals(1, prs.size())
+
+      def pr = prs.get(0)
+      assertEquals('refs/heads/change', pr.ref())
+      assertEquals(repoUrl('gocd/gocd'), pr.url())
+      assertEquals('Such a fancy PR', pr.title())
+      assertEquals('the-boss', pr.author())
+      assertEquals('https://greathub.com/pull/my/finger', pr.showUrl())
     }
 
     def from(String branch, String reponame) {

--- a/resolvers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/resolvers/Branches.java
+++ b/resolvers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/resolvers/Branches.java
@@ -16,7 +16,7 @@
 
 package cd.go.contrib.plugins.configrepo.groovy.resolvers;
 
-import cd.go.contrib.plugins.configrepo.groovy.branching.MergeParent;
+import cd.go.contrib.plugins.configrepo.groovy.branching.MergeCandidate;
 import cd.go.contrib.plugins.configrepo.groovy.dsl.BranchContext;
 import cd.go.contrib.plugins.configrepo.groovy.dsl.strategies.BranchStrategy;
 
@@ -67,9 +67,30 @@ public class Branches {
      * @return a {@link List} of {@link BranchContext} instances
      */
     public static List<BranchContext> stubbed(final BranchStrategy s, @SuppressWarnings("unused") final Pattern p) {
-        final String ref = "refs/heads/stubbed-ref-" + randomHex();
+        final String identifier = randomHex();
+        final String ref = "refs/heads/stubbed-ref-" + identifier;
 
-        return Collections.singletonList(createContext(s.attrs(), new MergeParent() {
+        return Collections.singletonList(createContext(s.attrs(), new MergeCandidate() {
+            @Override
+            public String title() {
+                return "stubbed-title-for-" + identifier;
+            }
+
+            @Override
+            public String author() {
+                return "stubbed-author";
+            }
+
+            @Override
+            public String showUrl() {
+                return "https://stubbed.repository.url/pulls/" + ref;
+            }
+
+            @Override
+            public List<String> labels() {
+                return Collections.emptyList();
+            }
+
             @Override
             public String ref() {
                 return ref;


### PR DESCRIPTION
Inject the following into `BranchContext` so that templates have the following information during binding:

- PR title
- PR author
- PR URL
- PR labels (if supported by provider)

This allows pipeline authors more flexibility building pipeline configurations as more information can be used for conditional logic and the like.