### PR TITLE
Deserialize short PR identifier (usually `repoName#prNumber`) into BranchContext

### DIFF
--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/BranchContext.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/BranchContext.java
@@ -47,6 +47,10 @@ public class BranchContext implements KeyVal.Mixin {
 
     @JsonProperty
     @NotEmpty
+    private String identifier;
+
+    @JsonProperty
+    @NotEmpty
     private String title;
 
     @JsonProperty

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/BasicGitRefProvider.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/BasicGitRefProvider.java
@@ -101,6 +101,11 @@ public class BasicGitRefProvider implements RefProvider {
         }
 
         @Override
+        public String identifier() {
+            return gitShortRef(ref);
+        }
+
+        @Override
         public String title() {
             return gitShortRef(ref);
         }

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/BranchHelper.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/BranchHelper.java
@@ -67,6 +67,7 @@ public class BranchHelper {
         final String branch = prettifyRef(gitShortRef(ref), attrs);
         final BranchContext bc = new BranchContext(ref, branch, createMaterial(attrs, merge));
 
+        bc.setIdentifier(requireNonNullElse(merge.identifier(), ""));
         bc.setTitle(requireNonNullElse(merge.title(), ""));
         bc.setAuthor(requireNonNullElse(merge.author(), ""));
         bc.setReferenceUrl(requireNonNullElse(merge.showUrl(), ""));

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/MergeCandidate.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/MergeCandidate.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 public interface MergeCandidate extends MergeParent {
 
+    String identifier();
+
     String title();
 
     String author();

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/MergeEndpoint.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/MergeEndpoint.java
@@ -36,6 +36,8 @@ public class MergeEndpoint implements MergeParent {
 
     private String repoUrl;
 
+    private String fullName;
+
     @Override
     public String ref() {
         return format("refs/heads/%s", branchName);
@@ -46,6 +48,10 @@ public class MergeEndpoint implements MergeParent {
         return repoUrl;
     }
 
+    public String fullName() {
+        return fullName;
+    }
+
     @JsonProperty("branch")
     @SuppressWarnings("unused")
     private void unpackBranchName(Map<String, Object> branchNode) {
@@ -54,14 +60,16 @@ public class MergeEndpoint implements MergeParent {
 
     @JsonProperty("repository")
     @SuppressWarnings("unused")
-    private void unpackRepositoryUrl(Map<String, Object> repoNode) {
+    private void unpackRepository(Map<String, Object> repoNode) {
         if (null != repoNode) {
             this.repoUrl = requireNonNull(
                     requireNonNull(
-                            unpackLinks(repoNode).get("html"), "Missing PR source repo clone link"
+                            unpackLinks(repoNode).get("html"), "Missing PR repo clone link"
                     ).get("href"),
-                    "Missing PR source repo HTTP clone URL"
+                    "Missing PR repo HTTP clone URL"
             );
+
+            this.fullName = (String) requireNonNull(repoNode.get("full_name"), "Missing PR repo full name");
         }
     }
 

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/PullRequest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import java.util.Map;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.StringUtils.firstNonBlank;
 
@@ -61,7 +62,7 @@ public class PullRequest implements MergeCandidate {
 
     @Override
     public String identifier() {
-        return Integer.toString(id);
+        return format("%s#%d", destination.fullName(), id);
     }
 
     @Override

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketcloud/PullRequest.java
@@ -31,6 +31,10 @@ public class PullRequest implements MergeCandidate {
 
     @JsonProperty
     @SuppressWarnings("unused")
+    private int id;
+
+    @JsonProperty
+    @SuppressWarnings("unused")
     private MergeEndpoint source;
 
     @JsonProperty
@@ -53,6 +57,11 @@ public class PullRequest implements MergeCandidate {
     @Override
     public String url() {
         return firstNonBlank(source.url(), destination.url());
+    }
+
+    @Override
+    public String identifier() {
+        return Integer.toString(id);
     }
 
     @Override

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketserver/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/bitbucketserver/PullRequest.java
@@ -28,6 +28,10 @@ import static java.util.Objects.requireNonNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PullRequest implements MergeCandidate {
 
+    @JsonProperty
+    @SuppressWarnings("unused")
+    private int id;
+
     private String branchName;
 
     private String repoUrl;
@@ -48,6 +52,11 @@ public class PullRequest implements MergeCandidate {
     @Override
     public String url() {
         return repoUrl;
+    }
+
+    @Override
+    public String identifier() {
+        return Integer.toString(id);
     }
 
     @Override

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/github/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/github/PullRequest.java
@@ -34,6 +34,8 @@ public class PullRequest implements MergeCandidate {
     @SuppressWarnings("unused")
     private int number;
 
+    private String fullName;
+
     @JsonProperty
     @SuppressWarnings("unused")
     private String title;
@@ -58,7 +60,7 @@ public class PullRequest implements MergeCandidate {
 
     @Override
     public String identifier() {
-        return Integer.toString(number);
+        return format("%s#%d", fullName, number);
     }
 
     @Override
@@ -83,12 +85,14 @@ public class PullRequest implements MergeCandidate {
 
     @JsonProperty("base")
     @SuppressWarnings({"unchecked", "unused"})
-    private void unpackRepoUrl(Map<String, Object> node) {
+    private void unpackRepo(Map<String, Object> node) {
         if (null != node) {
-            repoUrl = requireNonNull((String) requireNonNull(
+            final Map<String, Object> repo = requireNonNull(
                     (Map<String, Object>) node.get("repo"),
                     "Missing PR repo"
-            ).get("clone_url"), "Missing PR repo clone URL");
+            );
+            repoUrl = requireNonNull((String) repo.get("clone_url"), "Missing PR repo clone URL");
+            fullName = requireNonNull((String) repo.get("full_name"), "Missig PR repo full name");
         }
     }
 

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/github/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/github/PullRequest.java
@@ -57,6 +57,11 @@ public class PullRequest implements MergeCandidate {
     }
 
     @Override
+    public String identifier() {
+        return Integer.toString(number);
+    }
+
+    @Override
     public String title() {
         return title;
     }

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/PullRequest.java
@@ -60,6 +60,11 @@ public class PullRequest implements MergeCandidate {
     }
 
     @Override
+    public String identifier() {
+        return Integer.toString(number);
+    }
+
+    @Override
     public String title() {
         return title;
     }

--- a/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/PullRequest.java
+++ b/providers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/branching/api/gitlab/PullRequest.java
@@ -35,6 +35,8 @@ public class PullRequest implements MergeCandidate {
     @SuppressWarnings("unused")
     private int number;
 
+    private String identifier;
+
     @JsonProperty
     @SuppressWarnings("unused")
     private String title;
@@ -61,7 +63,7 @@ public class PullRequest implements MergeCandidate {
 
     @Override
     public String identifier() {
-        return Integer.toString(number);
+        return identifier;
     }
 
     @Override
@@ -95,5 +97,10 @@ public class PullRequest implements MergeCandidate {
     @SuppressWarnings("unused")
     private void unpackAuthor(Map<String, String> node) {
         author = requireNonNull(node.get("username"), "Missing MR author username");
+    }
+
+    @JsonProperty("references")
+    private void unpackIdentifier(Map<String, String> node) {
+        identifier = requireNonNull(node.get("full"), "Missing PR full reference");
     }
 }

--- a/providers/src/test/groovy/cd/go/contrib/plugins/configrepo/groovy/branching/api/ApiTest.groovy
+++ b/providers/src/test/groovy/cd/go/contrib/plugins/configrepo/groovy/branching/api/ApiTest.groovy
@@ -110,6 +110,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
+      assertEquals('1', pr.identifier())
       assertEquals('refs/pull/1/head', pr.ref())
       assertEquals('git.repo', pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -195,6 +196,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
+      assertEquals('5', pr.identifier())
       assertEquals('refs/merge-requests/5/head', pr.ref())
       assertEquals('https://repo.com/gocd/gocd', pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -290,6 +292,7 @@ class ApiTest {
           r.body = toJson([
             page  : 1,
             values: [[
+              id: 3,
               source: internal("change"), destination: master("gocd/gocd"),
               title : 'Such a fancy PR',
               author: [nickname: 'the-boss'],
@@ -304,6 +307,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
+      assertEquals('3', pr.identifier())
       assertEquals('refs/heads/change', pr.ref())
       assertEquals('https://bb.org/gocd/gocd', pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -421,6 +425,7 @@ class ApiTest {
             isLastPage: true,
             start     : 0,
             values    : [[
+              id: 5,
               fromRef: from("change", "gocd/gocd"),
               title  : 'Such a fancy PR',
               author : [user: [name: 'the-boss']],
@@ -435,6 +440,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
+      assertEquals('5', pr.identifier())
       assertEquals('refs/heads/change', pr.ref())
       assertEquals(repoUrl('gocd/gocd'), pr.url())
       assertEquals('Such a fancy PR', pr.title())

--- a/providers/src/test/groovy/cd/go/contrib/plugins/configrepo/groovy/branching/api/ApiTest.groovy
+++ b/providers/src/test/groovy/cd/go/contrib/plugins/configrepo/groovy/branching/api/ApiTest.groovy
@@ -52,7 +52,7 @@ class ApiTest {
     void 'fetches pull requests'() {
       GithubService api = Api.github(
         new MockedHttp().GET('/repos/gocd/gocd/pulls', { r ->
-          r.body = '[ { "number": 1, "state": "open", "base": { "repo": { "clone_url": "git.repo" } } } ]'
+          r.body = toJson([[number: 1, state: 'open', base: [repo: [clone_url: 'git.repo', full_name: 'gocd/gocd']]]])
         })
       )
       def prs = api.allPullRequests('gocd', 'gocd')
@@ -67,15 +67,15 @@ class ApiTest {
       GithubService api = Api.github(new MockedHttp().
         GET('/repos/gocd/gocd/pulls', { r ->
           r.headers.add(PAGING_HEADER, '<https://api.github.com/repositories/1234/pulls?page=2>; rel="next"')
-          r.body = '[ { "number": 1, "state": "open", "base": { "repo": { "clone_url": "git.repo" } } } ]'
+          r.body = toJson([[number: 1, state: 'open', base: [repo: [clone_url: 'git.repo', full_name: 'repositories/1234']]]])
         }).
         GET('/repos/gocd/gocd/pulls?page=2', { r ->
           r.headers.add(PAGING_HEADER, '<https://api.github.com/repositories/1234/pulls?page=3>; rel="next"')
-          r.body = '[ { "number": 2, "state": "open", "base": { "repo": { "clone_url": "git.repo" } } } ]'
+          r.body = toJson([[number: 2, state: 'open', base: [repo: [clone_url: 'git.repo', full_name: 'repositories/1234']]]])
         }).
         GET('/repos/gocd/gocd/pulls?page=3', { r ->
           r.headers.add(PAGING_HEADER, '<https://api.github.com/repositories/1234/pulls?page=2>; rel="prev"')
-          r.body = '[ { "number": 3, "state": "open", "base": { "repo": { "clone_url": "git.repo" } } } ]'
+          r.body = toJson([[number: 3, state: 'open', base: [repo: [clone_url: 'git.repo', full_name: 'repositories/1234']]]])
         })
       )
       def prs = api.allPullRequests('gocd', 'gocd')
@@ -97,7 +97,7 @@ class ApiTest {
       GithubService api = Api.github(
         new MockedHttp().GET('/repos/gocd/gocd/pulls', { r ->
           r.body = toJson([[
-            number: 1, state: 'open', base: [repo: [clone_url: 'git.repo']],
+            number: 1, state: 'open', base: [repo: [clone_url: 'git.repo', full_name: 'gocd/gocd']],
             labels: [[name: 'red'], [name: 'green']],
             title : 'Such a fancy PR',
             user  : [login: 'the-boss'],
@@ -110,7 +110,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
-      assertEquals('1', pr.identifier())
+      assertEquals('gocd/gocd#1', pr.identifier())
       assertEquals('refs/pull/1/head', pr.ref())
       assertEquals('git.repo', pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -140,7 +140,7 @@ class ApiTest {
     void 'fetches pull requests'() {
       GitlabService api = Api.gitlab(
         new MockedHttp().GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened', { r ->
-          r.body = '[ {"iid": 5, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/5"} ]'
+          r.body = toJson([[iid: 5, web_url: 'https://repo.com/gocd/gocd/-/merge_requests/5']])
         }), null
       )
       def prs = api.allPullRequests('gocd', 'gocd')
@@ -155,14 +155,14 @@ class ApiTest {
       GitlabService api = Api.gitlab(new MockedHttp().
         GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened', { r ->
           r.headers.add(PAGING_HEADER, '2')
-          r.body = '[ {"iid": 5, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/5"} ]'
+          r.body = toJson([[iid: 5, web_url: 'https://repo.com/gocd/gocd/-/merge_requests/5']])
         }).
         GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&page=2', { r ->
           r.headers.add(PAGING_HEADER, '3')
-          r.body = '[ {"iid": 6, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/6"} ]'
+          r.body = toJson([[iid: 6, web_url: 'https://repo.com/gocd/gocd/-/merge_requests/6']])
         }).
         GET('/api/v4/projects/gocd%2Fgocd/merge_requests?state=opened&page=3', { r ->
-          r.body = '[ {"iid": 7, "web_url": "https://repo.com/gocd/gocd/-/merge_requests/7"} ]'
+          r.body = toJson([[iid: 7, web_url: 'https://repo.com/gocd/gocd/-/merge_requests/7']])
         }), null
       )
       def prs = api.allPullRequests('gocd', 'gocd')
@@ -188,6 +188,7 @@ class ApiTest {
             labels: ['red', 'green'],
             title : 'Such a fancy PR',
             author: [username: 'the-boss'],
+            references: [full: 'gocd/gocd!5']
           ]])
         }), null
       )
@@ -196,7 +197,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
-      assertEquals('5', pr.identifier())
+      assertEquals('gocd/gocd!5', pr.identifier())
       assertEquals('refs/merge-requests/5/head', pr.ref())
       assertEquals('https://repo.com/gocd/gocd', pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -307,7 +308,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
-      assertEquals('3', pr.identifier())
+      assertEquals('gocd/gocd#3', pr.identifier())
       assertEquals('refs/heads/change', pr.ref())
       assertEquals('https://bb.org/gocd/gocd', pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -333,7 +334,7 @@ class ApiTest {
       }
       return [
         branch    : [name: branch],
-        repository: [links: [html: [href: format("https://bb.org/%s", reponame)]]]
+        repository: [links: [html: [href: format("https://bb.org/%s", reponame)]], full_name: reponame]
       ]
     }
   }
@@ -427,6 +428,7 @@ class ApiTest {
             values    : [[
               id: 5,
               fromRef: from("change", "gocd/gocd"),
+              toRef: to("master", "gocd/gocd"),
               title  : 'Such a fancy PR',
               author : [user: [name: 'the-boss']],
               links  : [self: [[href: 'https://greathub.com/pull/my/finger']]],
@@ -440,7 +442,7 @@ class ApiTest {
       assertEquals(1, prs.size())
 
       def pr = prs.get(0)
-      assertEquals('5', pr.identifier())
+      assertEquals('gocd/gocd#5', pr.identifier())
       assertEquals('refs/heads/change', pr.ref())
       assertEquals(repoUrl('gocd/gocd'), pr.url())
       assertEquals('Such a fancy PR', pr.title())
@@ -452,14 +454,22 @@ class ApiTest {
       return mergePoint(branch, reponame)
     }
 
+    def to(String branch, String reponame) {
+      return mergePoint(branch, reponame)
+    }
+
     def repoUrl(String name) {
       return [BASE_URL, name].join("/")
     }
 
     private def mergePoint(String branch, String reponame) {
+      final String[] parts = reponame.split("/")
+      final String project = parts[0]
+      final String slug = parts[1]
+
       return [
         id        : format("refs/heads/%s", branch),
-        repository: [links: [clone: [[href: repoUrl(reponame), name: "http"]]]]
+        repository: [links: [clone: [[href: repoUrl(reponame), name: "http"]]], slug: slug, project: [key: project]]
       ]
     }
   }

--- a/resolvers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/resolvers/Branches.java
+++ b/resolvers/src/main/java/cd/go/contrib/plugins/configrepo/groovy/resolvers/Branches.java
@@ -72,6 +72,11 @@ public class Branches {
 
         return Collections.singletonList(createContext(s.attrs(), new MergeCandidate() {
             @Override
+            public String identifier() {
+                return "stubbed-pr-number-" + identifier;
+            }
+
+            @Override
             public String title() {
                 return "stubbed-title-for-" + identifier;
             }


### PR DESCRIPTION
This will be useful in configuring build status notifications as the target.