### PR TITLE
Change whitelist to includes

### DIFF
--- a/json/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/json/FilterDeserializer.java
+++ b/json/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/json/FilterDeserializer.java
@@ -50,9 +50,9 @@ public class FilterDeserializer extends StdDeserializer<Filter> {
             if (objectNode.has("ignore")) {
                 isWhitelist = false;
                 itemsAsArray = (ArrayNode) objectNode.get("ignore");
-            } else if (objectNode.has("whitelist")) {
+            } else if (objectNode.has("includes")) {
                 isWhitelist = true;
-                itemsAsArray = (ArrayNode) objectNode.get("whitelist");
+                itemsAsArray = (ArrayNode) objectNode.get("includes");
             } else {
                 throw new UnrecognizedPropertyException(p, "Filter contains neither a whitelist nor an ignore", p.getCurrentLocation(), getClass(), "filter", null);
             }

--- a/json/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/json/FilterSerializer.java
+++ b/json/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/json/FilterSerializer.java
@@ -33,7 +33,7 @@ public class FilterSerializer extends StdSerializer<Filter> {
 
     @Override
     public void serialize(Filter value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        String key = value.isWhitelist() ? "whitelist" : "ignore";
+        String key = value.isWhitelist() ? "includes" : "ignore";
         List<String> items = value.getItems();
 
         gen.writeObject(Collections.singletonMap(key, items));

--- a/json/src/test/resources/parts/materials/complete.git.groovy
+++ b/json/src/test/resources/parts/materials/complete.git.groovy
@@ -20,7 +20,7 @@ import cd.go.contrib.plugins.configrepo.groovy.dsl.Materials
 
 return new Materials().git('gitMaterial1') {
   autoUpdate = false
-  blacklist = ['externals', 'tools']
+  whitelist = ['externals', 'tools']
   branch = 'feature12'
   destination = 'dir1'
   encryptedPassword = 'some encrypted password'

--- a/json/src/test/resources/parts/materials/complete.git.groovy
+++ b/json/src/test/resources/parts/materials/complete.git.groovy
@@ -20,11 +20,11 @@ import cd.go.contrib.plugins.configrepo.groovy.dsl.Materials
 
 return new Materials().git('gitMaterial1') {
   autoUpdate = false
-  whitelist = ['externals', 'tools']
   branch = 'feature12'
   destination = 'dir1'
   encryptedPassword = 'some encrypted password'
   shallowClone = true
   url = 'http://my.git.repository.com'
   username = 'username'
+  whitelist = ['externals', 'tools']
 }

--- a/json/src/test/resources/parts/materials/complete.git.json
+++ b/json/src/test/resources/parts/materials/complete.git.json
@@ -6,7 +6,7 @@
   "url": "http://my.git.repository.com",
   "branch": "feature12",
   "filter": {
-    "whitelist": [
+    "includes": [
       "externals",
       "tools"
     ]

--- a/json/src/test/resources/parts/materials/complete.git.json
+++ b/json/src/test/resources/parts/materials/complete.git.json
@@ -6,7 +6,7 @@
   "url": "http://my.git.repository.com",
   "branch": "feature12",
   "filter": {
-    "ignore": [
+    "whitelist": [
       "externals",
       "tools"
     ]


### PR DESCRIPTION
- Similar to https://github.com/tomzo/gocd-yaml-config-plugin/pull/143

- Expect `includes` in the input for Groovy export, and use it.

- Similar to https://github.com/tomzo/gocd-yaml-config-plugin/pull/143, this does not change the groovy output. So, it still contains `whitelist` and `blacklist`. Need to think about how to support existing config repo files while supporting a new set of replacement terms.

#### Manual test:

1. Used this YAML:


    <details>
        <summary>Input YAML</summary>

    ```yaml
    format_version: 9
    pipelines:
      p1:
        group: group1
        label_template: ${COUNT}
        lock_behavior: none
        display_order: -1
        materials:
          git_material1:
            git: https://github.com/arvindsv/faketime.git
            whitelist:
            - dir1
            - dir2
            shallow_clone: false
            auto_update: true
            branch: master
            destination: dir1
          git_material2:
            git: https://github.com/arvindsv/faketime2.git
            blacklist:
            - dir1
            - dir2
            shallow_clone: false
            auto_update: true
            branch: master
            destination: dir2
          git_material3:
            git: https://github.com/arvindsv/faketime2.git
            shallow_clone: false
            auto_update: true
            branch: master
            destination: dir3
        stages:
        - build:
            fetch_materials: true
            keep_artifacts: false
            clean_workspace: false
            approval:
              type: success
              allow_only_on_success: false
            jobs:
              build:
                timeout: 0
                tasks:
                - exec:
                    command: rake
                    run_if: passed
    ```

    </details>


2. Exported it to Groovy.


    <details>
        <summary>The exported Groovy file</summary>
    
    ```groovy
    /*
     * This file was automatically exported by the GoCD Groovy DSL Plugin.
     */
    
    GoCD.script {
      pipelines {
        pipeline('p1') {
          group = 'group1'
          labelTemplate = '${COUNT}'
          lockBehavior = 'none'
          materials {
            git('git_material1') {
              branch = 'master'
              destination = 'dir1'
              shallowClone = false
              url = 'https://github.com/arvindsv/faketime.git'
              whitelist = ['dir1', 'dir2']
            }
            git('git_material2') {
              blacklist = ['dir1', 'dir2']
              branch = 'master'
              destination = 'dir2'
              shallowClone = false
              url = 'https://github.com/arvindsv/faketime2.git'
            }
            git('git_material3') {
              branch = 'master'
              destination = 'dir3'
              shallowClone = false
              url = 'https://github.com/arvindsv/faketime2.git'
            }
          }
          stages {
            stage('build') {
              artifactCleanupProhibited = false
              cleanWorkingDir = false
              fetchMaterials = true
              approval {
              }
              jobs {
                job('build') {
                  timeout = 0
                  tasks {
                    exec {
                      commandLine = ['rake']
                      runIf = 'passed'
                    }
                  }
                }
              }
            }
          }
        }
      }
    }
    ```
    
    </details>

3. Imported the pipeline back using a config repo belonging to the Groovy plugin.

4. Exported it back to YAML.

5. Verified that the YAMLs in steps 1 and 4 are identical.
