### PR TITLE
Allows plugin tests to resolve the plugin API

### DIFF
--- a/gocd-groovy-dsl-config-plugin/build.gradle
+++ b/gocd-groovy-dsl-config-plugin/build.gradle
@@ -42,6 +42,7 @@ dependencies {
   annotationProcessor project.deps.hibernateValidatorAnnotationProcessor
 
   compileOnly project.deps.pluginApi
+  testCompileOnly project.deps.pluginApi
 
   testRuntimeOnly project.deps.junitJupiterEngine
   testImplementation project.deps.junitJupiterApi


### PR DESCRIPTION
I'm really not sure how these were working beforehand, as nothing seems to have changed since the last commit which had a green build, but it is definitely failing now: https://build.gocd.org/go/tab/build/detail/gocd-contrib-gocd-groovy-dsl-config-plugin/96/test/1/test (and on all the PR builds).

Not quite sure how this was working before, but I suppose it could have been a change in the `gocd-plugin-gradle-task-helpers` which are not source controlled?