### PR TITLE
Upgrade dom4j from 1.6.1 to 2.1.3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,7 +26,7 @@ final Map<String, String> libraries = [
   classgraph        : 'io.github.classgraph:classgraph:4.8.138',
   commonsLang       : 'org.apache.commons:commons-lang3:3.12.0',
   commonsText       : 'org.apache.commons:commons-text:1.9',
-  dom4j             : 'dom4j:dom4j:1.6.1',
+  dom4j             : 'org.dom4j:dom4j:2.1.3',
   glassfish         : 'org.glassfish:javax.el:3.0.0',
   groovy            : 'org.codehaus.groovy:groovy:3.0.9',
   guava             : 'com.google.guava:guava:31.0.1-jre',

--- a/dsl/build.gradle
+++ b/dsl/build.gradle
@@ -42,7 +42,10 @@ dependencies {
 
   testImplementation project.deps.reflections
   testImplementation project.deps.classgraph
-  testImplementation project.deps.dom4j
+  testImplementation(project.deps.dom4j) {
+    // workaround for dom4j Gradle metadata optional dependency issues (https://github.com/dom4j/dom4j/issues/99)
+    transitive = false
+  }
 }
 
 test {


### PR DESCRIPTION
Only used in tests, but can see https://github.com/gocd/gocd/pull/9939 for a fuller explanation