### PR TITLE
Allow artifact fetch tasks have an undefined pipeline

### DIFF
--- a/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/AbstractFetchArtifactTask.java
+++ b/dsl/src/main/java/cd/go/contrib/plugins/configrepo/groovy/dsl/AbstractFetchArtifactTask.java
@@ -34,7 +34,6 @@ public abstract class AbstractFetchArtifactTask extends Task<AbstractFetchArtifa
     protected String artifactOrigin = "gocd";
 
     @JsonProperty("pipeline")
-    @NotEmpty
     protected String pipeline;
 
     @JsonProperty("stage")

--- a/json/src/test/resources/parts/tasks/complete.fetchDirectory.defaultPipeline.groovy
+++ b/json/src/test/resources/parts/tasks/complete.fetchDirectory.defaultPipeline.groovy
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parts.tasks
+
+import cd.go.contrib.plugins.configrepo.groovy.dsl.Tasks
+
+return new Tasks().fetchArtifact {
+  destination = 'test'
+  job = 'upstream_job'
+  runIf = 'any'
+  source = 'result'
+  stage = 'upstream_stage'
+}

--- a/json/src/test/resources/parts/tasks/complete.fetchDirectory.defaultPipeline.json
+++ b/json/src/test/resources/parts/tasks/complete.fetchDirectory.defaultPipeline.json
@@ -1,0 +1,10 @@
+{
+  "type": "fetch",
+  "run_if": "any",
+  "stage": "upstream_stage",
+  "job": "upstream_job",
+  "is_source_a_file": false,
+  "artifact_origin": "gocd",
+  "source": "result",
+  "destination": "test"
+}


### PR DESCRIPTION
Fixes #314 

This is generally supposed to be optional, and GoCD should use the current pipeline if it's undefined, to make it easier to fetch an artifact from an earlier stage and job in the same pipeline. The YAML config plugin already works this way, so this should be safe.

Still to be validated/tested.